### PR TITLE
Shortcode groups

### DIFF
--- a/includes/class-shortcode-interface.php
+++ b/includes/class-shortcode-interface.php
@@ -11,7 +11,8 @@ if ( ! class_exists( 'WP_SCIF_Shortcode' ) ) {
 			$description,
 			$fields,
 			$content,
-			$preview=FALSE;
+			$preview=FALSE,
+			$group;
 
 		/**
 		 * Primary constructor for Shortcode object

--- a/includes/class-shortcode-interface.php
+++ b/includes/class-shortcode-interface.php
@@ -29,6 +29,7 @@ if ( ! class_exists( 'WP_SCIF_Shortcode' ) ) {
 			$this->content = isset( $args['content'] ) ? $args['content'] : false;
 			$this->description = isset( $args['desc'] ) ? $args['desc'] : '';
 			$this->preview = isset( $args['preview'] ) ? $args['preview'] : false;
+			$this->group = isset( $args['group'] ) ? $args['group'] : apply_filters( 'wp_scif_default_sc_group', 'Uncategorized' );
 		}
 
 		/**

--- a/includes/wp-scif-config.php
+++ b/includes/wp-scif-config.php
@@ -42,6 +42,7 @@ if ( ! class_exists( 'WP_SCIF_Config' ) ) {
 				}
 			}
 
+			ksort( $retval );
 			return $retval;
 		}
 	}

--- a/includes/wp-scif-config.php
+++ b/includes/wp-scif-config.php
@@ -22,5 +22,27 @@ if ( ! class_exists( 'WP_SCIF_Config' ) ) {
 			}
 			return $retval;
 		}
+
+		/**
+		 * Returns an array of grouped shortcodes for output on the shortcode
+		 * interface.
+		 *
+		 * @author Jo Dickson
+		 * @since 1.0.0
+		 * @param $shortcodes Mixed | an array of WP_SCIF_Shortcode objects, or null
+		 * @return Array | an associative array of grouped WP_SCIF_Shortcode objects, with keys as group names
+		 **/
+		public static function installed_shortcodes_grouped( $shortcodes=null ) {
+			$shortcodes = is_array( $shortcodes ) ? $shortcodes : self::installed_shortcodes();
+			$retval = array();
+
+			if ( !empty( $shortcodes ) ) {
+				foreach ( $shortcodes as $shortcode ) {
+					$retval[$shortcode->group][] = $shortcode;
+				}
+			}
+
+			return $retval;
+		}
 	}
 }

--- a/includes/wp-scif-interface.php
+++ b/includes/wp-scif-interface.php
@@ -16,11 +16,11 @@ $shortcodes_grouped = WP_SCIF_Config::installed_shortcodes_grouped( $shortcodes 
                 <select name="wp-scif-select" id="wp-scif-select">
                     <option value="">--Choose Shortcode--</option>
                     <?php
-                    foreach( $shortcodes_grouped as $group=>$shortcodes ):
+                    foreach( $shortcodes_grouped as $group=>$group_items ):
 					?>
 						<optgroup label="<?php echo $group; ?>">
 						<?php
-						foreach ( $shortcodes as $shortcode ) {
+						foreach ( $group_items as $shortcode ) {
 							echo $shortcode->get_option_markup();
 						}
 						?>

--- a/includes/wp-scif-interface.php
+++ b/includes/wp-scif-interface.php
@@ -3,6 +3,7 @@
  * Shortcode Interface
  **/
 $shortcodes = WP_SCIF_Config::installed_shortcodes();
+$shortcodes_grouped = WP_SCIF_Config::installed_shortcodes_grouped( $shortcodes );
 ?>
 <div id="wp-scif-form" style="display:none">
     <div id="wp-scif-form-inner">
@@ -15,9 +16,17 @@ $shortcodes = WP_SCIF_Config::installed_shortcodes();
                 <select name="wp-scif-select" id="wp-scif-select">
                     <option value="">--Choose Shortcode--</option>
                     <?php
-                    foreach( $shortcodes as $shortcode ) {
-                        echo $shortcode->get_option_markup();
-                    }
+                    foreach( $shortcodes_grouped as $group=>$shortcodes ):
+					?>
+						<optgroup label="<?php echo $group; ?>">
+						<?php
+						foreach ( $shortcodes as $shortcode ) {
+							echo $shortcode->get_option_markup();
+						}
+						?>
+                        </optgroup>
+					<?php
+                    endforeach;
                     ?>
                 </select>
             </div>

--- a/includes/wp-scif-interface.php
+++ b/includes/wp-scif-interface.php
@@ -6,17 +6,17 @@ $shortcodes = WP_SCIF_Config::installed_shortcodes();
 $shortcodes_grouped = WP_SCIF_Config::installed_shortcodes_grouped( $shortcodes );
 ?>
 <div id="wp-scif-form" style="display:none">
-    <div id="wp-scif-form-inner">
-        <label for="wp-scif-select">Select a shortcode: </label>
-        <p class="help-text">
-            This shortcode will be inserted into the editor when you click the "Insert into Post" button.
-        </p>
-        <div class="cols">
-            <div class="col-left">
-                <select name="wp-scif-select" id="wp-scif-select">
-                    <option value="">--Choose Shortcode--</option>
-                    <?php
-                    foreach( $shortcodes_grouped as $group=>$group_items ):
+	<div id="wp-scif-form-inner">
+		<label for="wp-scif-select">Select a shortcode: </label>
+		<p class="help-text">
+			This shortcode will be inserted into the editor when you click the "Insert into Post" button.
+		</p>
+		<div class="cols">
+			<div class="col-left">
+				<select name="wp-scif-select" id="wp-scif-select">
+					<option value="">--Choose Shortcode--</option>
+					<?php
+					foreach( $shortcodes_grouped as $group=>$group_items ):
 					?>
 						<optgroup label="<?php echo esc_attr( $group ); ?>">
 						<?php
@@ -24,22 +24,22 @@ $shortcodes_grouped = WP_SCIF_Config::installed_shortcodes_grouped( $shortcodes 
 							echo $shortcode->get_option_markup();
 						}
 						?>
-                        </optgroup>
+						</optgroup>
 					<?php
-                    endforeach;
-                    ?>
-                </select>
-            </div>
-            <div class="col-right">
-                <div id="shortcode-descriptions">
-                    <?php
-                    foreach( $shortcodes as $shortcode ) {
-                        echo $shortcode->get_description_markup();
-                    }
-                    ?>
-                </div>
-            </div>
-        </div>
+					endforeach;
+					?>
+				</select>
+			</div>
+			<div class="col-right">
+				<div id="shortcode-descriptions">
+					<?php
+					foreach( $shortcodes as $shortcode ) {
+						echo $shortcode->get_description_markup();
+					}
+					?>
+				</div>
+			</div>
+		</div>
 		<div class="cols" id="scif-form-body">
 			<div class="col-left" id="shortcode-editors">
 				<?php
@@ -55,5 +55,5 @@ $shortcodes_grouped = WP_SCIF_Config::installed_shortcodes_grouped( $shortcodes 
 			</div>
 		</div>
 		<button class="button-primary" id="wp-scif-submit">Insert into Post</button>
-    </div>
+	</div>
 </div>

--- a/includes/wp-scif-interface.php
+++ b/includes/wp-scif-interface.php
@@ -18,7 +18,7 @@ $shortcodes_grouped = WP_SCIF_Config::installed_shortcodes_grouped( $shortcodes 
                     <?php
                     foreach( $shortcodes_grouped as $group=>$group_items ):
 					?>
-						<optgroup label="<?php echo $group; ?>">
+						<optgroup label="<?php echo esc_attr( $group ); ?>">
 						<?php
 						foreach ( $group_items as $shortcode ) {
 							echo $shortcode->get_option_markup();


### PR DESCRIPTION
With the number of new shortcodes we've developed, particularly with the Athena Shortcodes plugin, navigating the dropdown of available shortcodes was starting to get a bit unwieldy, so I wrote this really quick to allow shortcodes to be assigned to groups.

![screen shot 2017-08-18 at 10 28 03 am](https://user-images.githubusercontent.com/1649216/29466324-195cea3a-8402-11e7-9810-85c4daee7e00.png)

By default, all registered shortcodes will be added to an 'Uncategorized' group (the default group name can be overridden using the `wp_scif_default_sc_group` hook).  Existing plugins that register shortcodes with WP SCIF should be compatible with this update.